### PR TITLE
Add auth route tests with Jest

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +19,8 @@
     "mongoose": "^8.16.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -3,8 +3,9 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const User = require('/Users/seokhyeonjang/auth-app/backend/model/User.js');
-const authMiddleware = require('/Users/seokhyeonjang/auth-app/backend/middleware/auth.js');
+const path = require('path');
+const User = require(path.join(__dirname, '../model/User.js'));
+const authMiddleware = require(path.join(__dirname, '../middleware/auth.js'));
 
 const router = express.Router();
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,4 +28,9 @@ app.get('/', (req, res) => {
 });
 
 const PORT = process.env.PORT || 5001;
-app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Auth Routes', () => {
+  const user = { email: 'test@example.com', password: 'Password123' };
+
+  test('Sign up a user', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send(user);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('message', 'User created');
+    expect(res.body).toHaveProperty('user');
+  });
+
+  test('Valid login returns token', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send(user);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token');
+  });
+
+  test('Invalid login returns 400', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: user.email, password: 'wrongpass' });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest` and `supertest` dev dependencies
- expose express app in `server.js`
- fix module paths in `auth.js`
- add basic auth route tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a2c081088331b00273c8ed54d4ba