### PR TITLE
Fix relative requires in auth routes

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -3,8 +3,8 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const User = require('/Users/seokhyeonjang/auth-app/backend/model/User.js');
-const authMiddleware = require('/Users/seokhyeonjang/auth-app/backend/middleware/auth.js');
+const User = require('../model/User.js');
+const authMiddleware = require('../middleware/auth.js');
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- use relative require paths for auth route

## Testing
- `npm test --prefix backend` *(fails: no test specified)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854af6d130483319c987a908bf86dc7