### PR TITLE
Fix product image URL handling

### DIFF
--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -3,9 +3,15 @@ import React from "react";
 import { Link } from "react-router-dom";
 import "./ProductCard.css";
 
-// 이미지 URL이 절대경로가 아닐 때만 백엔드 서버 주소를 붙여주는 헬퍼
-const getImageUrl = (path) =>
-  path.startsWith("http") ? path : `http://localhost:5001${path}`;
+// 이미지 경로를 절대 URL로 변환
+const getImageUrl = (path) => {
+  if (!path) return "";
+  if (path.startsWith("http")) return path;
+  if (path.startsWith("/uploads")) {
+    return `http://localhost:5001${path}`;
+  }
+  return `http://localhost:5001/uploads/${path.replace(/^uploads\//, "")}`;
+};
 
 export default function ProductCard({ product, onEdit, onDelete }) {
   if (!product) return null;

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -4,9 +4,15 @@ import axios from "axios";
 import { useParams, useNavigate } from "react-router-dom";
 import "./ProductDetail.css";
 
-// helper: 서버가 넘겨주는 path가 절대 URL 아닐 때만 prefix
-const getImageUrl = (path) =>
-  path.startsWith("http") ? path : `/uploads/${path}`;
+// 이미지 경로를 절대 URL로 변환
+const getImageUrl = (path) => {
+  if (!path) return "";
+  if (path.startsWith("http")) return path;
+  if (path.startsWith("/uploads")) {
+    return `http://localhost:5001${path}`;
+  }
+  return `http://localhost:5001/uploads/${path.replace(/^uploads\//, "")}`;
+};
 
 export default function ProductDetail() {
   const { id } = useParams();


### PR DESCRIPTION
## Summary
- add a more robust `getImageUrl` helper
- update product card and detail pages to use the new logic

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687439bd626c833196cc7d10b8c92c7d